### PR TITLE
use alpine 3.19.1 as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.16.0
+FROM alpine:3.19.1
 RUN apk add --no-cache openssh && ssh-keygen -A && echo 'root:root' | chpasswd


### PR DESCRIPTION
to stay up to date and remove vulnerabilities