### PR TITLE
chore: include common CMD used across all libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.19.1
 RUN apk add --no-cache openssh && ssh-keygen -A
 
-ENV USERNAME "root"
-ENV PASSWORD "root"
+ENV USERNAME="root"
+ENV PASSWORD="root"
 
 ENTRYPOINT ["sh", "-c"]
-CMD ["echo '${USERNAME}:${PASSWORD}' | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa"]
+CMD ["echo ${USERNAME}:${PASSWORD} | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,8 @@
 FROM alpine:3.19.1
-RUN apk add --no-cache openssh && ssh-keygen -A && echo 'root:root' | chpasswd
+# Disable ipv6 & Make it listen on all interfaces, not just localhost
+# Enable algorithms supported by our ssh client library
+RUN apk add --no-cache openssh && ssh-keygen -A \
+    && echo 'root:root' | chpasswd && \
+    /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet \
+    -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes \
+    -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.19.1
 RUN apk add --no-cache openssh && ssh-keygen -A
 
+ENV USERNAME "root"
+ENV PASSWORD "root"
+
 ENTRYPOINT ["sh", "-c"]
-CMD ["echo 'root:root' | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa"]
+CMD ["echo '${USERNAME}:${PASSWORD}' | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM alpine:3.19.1
-# Disable ipv6 & Make it listen on all interfaces, not just localhost
-# Enable algorithms supported by our ssh client library
-RUN apk add --no-cache openssh && ssh-keygen -A \
-    && echo 'root:root' | chpasswd && \
-    /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet \
-    -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes \
-    -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa
+RUN apk add --no-cache openssh && ssh-keygen -A && echo 'root:root' | chpasswd
+
+ENTRYPOINT ["/usr/sbin/sshd"]
+CMD ["-D", "-o", "PermitRootLogin=yes", "-o", "AddressFamily=inet", "-o", "GatewayPorts=yes", "-o", "AllowAgentForwarding=yes", "-o", "AllowTcpForwarding=yes", "-o", "KexAlgorithms=+diffie-hellman-group1-sha1", "-o", "HostkeyAlgorithms=+ssh-rsa"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.19.1
-RUN apk add --no-cache openssh && ssh-keygen -A && echo 'root:root' | chpasswd
+RUN apk add --no-cache openssh && ssh-keygen -A
 
-ENTRYPOINT ["/usr/sbin/sshd"]
-CMD ["-D", "-o", "PermitRootLogin=yes", "-o", "AddressFamily=inet", "-o", "GatewayPorts=yes", "-o", "AllowAgentForwarding=yes", "-o", "AllowTcpForwarding=yes", "-o", "KexAlgorithms=+diffie-hellman-group1-sha1", "-o", "HostkeyAlgorithms=+ssh-rsa"]
+ENTRYPOINT ["sh", "-c"]
+CMD ["echo 'root:root' | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes -o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa"]


### PR DESCRIPTION
## What does this PR do?
It adds the CMD command that is used in [testcontainers-java](https://github.com/testcontainers/testcontainers-java/blob/e5c8b1a5e2c0835ad6574416daba9feac9c6824d/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java#L30-L38), [dotnet](https://github.com/testcontainers/testcontainers-dotnet/blob/136ca49a2b95192c1a535b1e998ef8f3f2fc276e/src/Testcontainers/Containers/PortForwarding.cs#L68-L75) [testcontainers-node](https://github.com/testcontainers/testcontainers-node/blob/59a62f401009d9d3b6c579929145fd619e71aa15/packages/testcontainers/src/port-forwarder/port-forwarder.ts#L130) or [testcontainers-go](https://github.com/testcontainers/testcontainers-go/pull/2471/files#diff-0823b41b3b2039f0d38298c6bd56e73f028530efc0b5ce4e0b8e12121b6bfa44R168-R170)


## Why is it important?
Reduce duplication across projects, building the image with the same CMD command for all.

## Follow-ups
Update the projects to consume the newest image, removing the custom CMD.

