### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+        interval: monthly
+        day: sunday
+      open-pull-requests-limit: 3
+      rebase-strategy: disabled
+    - package-ecosystem: docker
+      directory: /
+      schedule:
+        interval: monthly
+        day: sunday


### PR DESCRIPTION
Adds dependabot to update the Dockefile and Github Action dependencies, in a monthly manner on Sundays
