### PR TITLE
Document how to use this container for exposing host ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # sshd-docker
 Docker image with SSH daemon installed
+
+# Usage
+This container is meant to be used to expose host ports to containers running in Docker.
+When using testcontainers in unit tests, refer to the documentation of testcontainers to find out how to use it:
+- Java: https://java.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
+- .NET: https://dotnet.testcontainers.org/api/create_docker_network/#exposing-host-ports-to-the-container
+- node.js: https://node.testcontainers.org/features/networking/#expose-host-ports-to-container
+
+Alternatively, you can start the container yourself:
+```yaml
+services:
+  sshd:
+    image: testcontainers/sshd:1.2.0
+    environment:
+      PASSWORD: "SET_YOUR_PASSWORD_HERE"
+    ports:
+      - 10022:22
+
+  requester:
+    image: curlimages/curl
+    command: /bin/sh -c "while true; do curl http://sshd:8080; sleep 5; done"
+    depends_on:
+      - sshd
+```
+
+And connect to it via ssh:
+
+```bash
+# ssh -R [remote_port]:[destination_address]:[local_port] [username]@[ssh_server]
+ssh -R 8080:localhost:8080 root@localhost:10022
+```
+
+Start your application and you should see requests coming from the requester service:
+
+```bash
+python3 -m http.server 8080
+```

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ services:
 And connect to it via ssh:
 
 ```bash
-# ssh -R [remote_port]:[destination_address]:[local_port] [username]@[ssh_server]
-ssh -R 8080:localhost:8080 root@localhost:10022
+# ssh -R [remote_port]:[destination_address]:[local_port] [username]@[ssh_server] -p [ssh_port]
+ssh -R 8080:localhost:8080 root@localhost -p 10022
 ```
 
 Start your application and you should see requests coming from the requester service:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ When using testcontainers in unit tests, refer to the documentation of testconta
 - Java: https://java.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
 - .NET: https://dotnet.testcontainers.org/api/create_docker_network/#exposing-host-ports-to-the-container
 - node.js: https://node.testcontainers.org/features/networking/#expose-host-ports-to-container
+- Go: https://golang.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
 
 Alternatively, you can start the container yourself:
 ```yaml


### PR DESCRIPTION
I heard about this feature at Devoxx Belgium 2024 and wanted to give this a try, but could not find the documentation for it.