### PR TITLE
chore: add permissions to workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,5 +1,8 @@
 name: Build multi-arch Docker Image
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/testcontainers/sshd-docker/security/code-scanning/1](https://github.com/testcontainers/sshd-docker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it primarily interacts with repository contents and uses the `GITHUB_TOKEN` for authentication with the GitHub Container Registry. Therefore, the `contents: read` permission is sufficient for most steps. If additional permissions are required for specific steps, they can be defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
